### PR TITLE
Geonames client extra params

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ $country_name = $country->countryName;
 
 // spoken languages (ISO-639-1)
 $country_languages = $country->languages;
+
+// change request URL - premium subdomain users
+$g = new GeoNamesClient('username', null, ['apiUrl' => 'request URL']);
 ```
 
 ## Why?

--- a/src/Client.php
+++ b/src/Client.php
@@ -192,7 +192,7 @@ class Client
      *
      * @param string $username Required for both Free and Commercial users.
      * @param string|null $token Optional. Commercial users only.
-     * @param array{"apiUrl"?: string} $options Optional - override target URL
+     * @param array{apiUrl: ?string} $options Optional - override target URL
      */
     public function __construct(string $username, string $token = null, array $options = [])
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -192,11 +192,15 @@ class Client
      *
      * @param string $username Required for both Free and Commercial users.
      * @param string|null $token Optional. Commercial users only.
+     * @param array{"apiUrl"?: string} $options Optional - override target URL
      */
-    public function __construct(string $username, string $token = null)
+    public function __construct(string $username, string $token = null, array $options = [])
     {
         $this->username = $username;
         $this->token = $token;
+        if (isset($options['apiUrl'])) {
+            $this->url = $options['apiUrl'];
+        }
     }
 
     /**
@@ -383,5 +387,10 @@ class Client
     public function setConnectTimeout(int $connect_timeout)
     {
         $this->connect_timeout = $connect_timeout;
+    }
+
+    public function getApiUrl(): string
+    {
+        return $this->url;
     }
 }

--- a/tests/GeoNames/ClientTest.php
+++ b/tests/GeoNames/ClientTest.php
@@ -354,4 +354,14 @@ final class ClientTest extends TestCase
 
         $this->assertEquals(10, $g->getConnectTimeout());
     }
+
+    public function testOverrideApiUrl()
+    {
+        $client = new GeoNamesClient(
+            $this->config['username'],
+            $this->config['token'],
+            ['apiUrl' => 'http://api.geonames.org']
+        );
+        $this->assertEquals('http://api.geonames.org', $client->getApiUrl());
+    }
 }


### PR DESCRIPTION
Adds an extra param to the client constructor to allow different target URLs